### PR TITLE
Linked NYC footer logo to main NYC site

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,9 +44,9 @@
 
       <div class="container">
          <center><a href="index.html"><img class="img-responsive" src="img/logo.png"></a></center>
-         
+
         <div class="navbar-header">
-          
+
           <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
             <span class="sr-only">Toggle navigation</span>
             <span class="icon-bar"></span>
@@ -92,7 +92,7 @@
           <center>
             <p class="lead">Here's why you should join us:</p>
           </center>
-          
+
           <div class="col-sm-4">
             <center>
               <img class="img-responsive" src="img/icon1.png">
@@ -127,7 +127,7 @@
 
 
       <div class="container">
-      
+
             <center>
               <p class="lead">Hear from our innovators on why they work for the City of New York:</p></br>
           </center>
@@ -289,7 +289,7 @@
 
       </div>
       <div class="col-md-3">
-            <img cclass="img-responsive" src="img/nyc.png">
+            <a href="http://www1.nyc.gov"><img cclass="img-responsive" src="img/nyc.png"></a>
             <p>City of New York. 2015 All Rights Reserved, NYC is a trademark and service mark of the City of New York.</p>
             <p><a target="_blank" href="http://www1.nyc.gov/home/privacy-policy.page" title="Privicy">Privacy Policy</a>.
             <a target="_blank" href="http://www1.nyc.gov/home/terms-of-use.page" title="TOU">Terms of Use</a>.</p>


### PR DESCRIPTION
Hi. 

The NYC footer logo was not linking back to the official website of the City of New York, so for the sake of consistency (the small header logo has a link) I decided to add the link to footer as well.

Thanks. 
